### PR TITLE
Fix Broken Bundle Param

### DIFF
--- a/src/lib/ModuleBundler.js
+++ b/src/lib/ModuleBundler.js
@@ -42,7 +42,7 @@ export default class ModuleBundler {
     await Promise.map(this.modules, async ({ packagePath, relativePath }) => {
       const onFile = async (basePath, stats, next) => {
         const relPath = path.join(
-          relativePath, basePath.split(relativePath)[1], stats.name
+          relativePath, basePath.split(relativePath)[1] || '', stats.name
         ).replace(/^\/|\/$/g, '');
 
         const filePath = path.join(basePath, stats.name);


### PR DESCRIPTION
Issue:

Bundle action breaks when bundling a project where the project includes a linked module.

The relativePath array only has 1 element and not 2 as its expecting. All/most other relativePath arrays have an empty string.
