### PR TITLE
Ensure the `sourceMaps` configuration option is respected if switched off

### DIFF
--- a/src/lib/SourceBundler.js
+++ b/src/lib/SourceBundler.js
@@ -98,7 +98,13 @@ export default class SourceBundler {
 
         babelQuery = fs.existsSync(babelrcPath)
           ? JSON.parse(await fs.readFileAsync(babelrcPath))
-          : babelQuery;
+          : {};
+      }
+
+      // If `sourceMaps` are switched off by the plugin's configuration,
+      // ensure that is passed down to the babel transformer too.
+      if (this.config.sourceMaps === false) {
+        babelQuery.sourceMaps = false;
       }
 
       transforms.push(new BabelTransform(babelQuery));


### PR DESCRIPTION
This small fix ensures that if the serverless build configuration sets `sourceMaps: false`, that this setting is passed down to Babel so that source maps are not added to the artifacts.

This also fixes a small bug where the Babel transformer could be a passed a boolean value, which leave the default of [`sourceMaps: 'both'`](https://github.com/nfour/serverless-build-plugin/blob/develop/src/lib/transforms/Babel.js#L4).

If `sourceMaps` is set to false in the build config, this will _override_ anything set by either a `.babelrc` file, or if `babel` is actually an object in the configuration and not a boolean.