### PR TITLE
Corrected creation of relative path names in artifact

### DIFF
--- a/src/lib/ModuleBundler.js
+++ b/src/lib/ModuleBundler.js
@@ -58,9 +58,7 @@ export default class ModuleBundler {
           return null;
         })
         .on('file', async (filePath, stats, next) => {
-          const relPath = path.join(
-            relativePath, filePath.split(relativePath)[1] || '',
-          ).replace(/^\/|\/$/g, '');
+          const relPath = filePath.substr(filePath.indexOf(relativePath)).replace(/^\/|\/$/g, '');
 
           await handleFile({
             filePath,


### PR DESCRIPTION
This fixes issue #21. 

### Code Changes
`filePath.split(relativePath)[1]` cannot be used for paths that look something like this: `/Users/arabold/Documents/myProject/node_modules/redis/node_modules/redis-commands/test/index.js`.

The `relativePath` in this case is `node_modules/redis` which results in a wrong split of the file path and thus causes a broken ZIP files as the paths get mangled.

This PR fixes this problem by properly extracting the `relPath` as a substring. 

You might want to check the implementation of the directory handling, too. Not sure if this will have a similar issue, too.