### PR TITLE
Add support for SLS 1.12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+  - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 
 node_js:
   - "6"
+
+before_script:
+  - "ls -la test/1.0/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
 
 before_script:
   - "ls -la test/1.0/"
-  - "cd test/1.0/ && npm install"
+  - "cd test/1.0/ && npm install && cd ../../"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
 
 before_script:
   - "ls -la test/1.0/"
+  - "cd test/1.0/ && npm install"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bluebird": "^3.5.0",
     "chalk": "^1.1.3",
     "findit": "^2.0.0",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^3.0.1",
     "graceful-fs": "~4.1.11",
     "is-stream": "~1.1.0",
     "js-yaml": "^3.8.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "minimatch": "^3.0.4",
     "mkdirp": "~0.5.1",
     "resolve-pkg": "~0.2.0",
+    "semver": "^5.3.0",
     "source-map-support": "^0.4.15",
     "uglify-js": "~2.7.0",
     "yauzl": "^2.8.0",

--- a/src/lib/ServerlessBuildPlugin.js
+++ b/src/lib/ServerlessBuildPlugin.js
@@ -4,6 +4,7 @@ import Yazl from 'yazl';
 import fs from 'fs-extra';
 import { typeOf, merge, clone } from 'lutils';
 import c from 'chalk';
+import semver from 'semver';
 
 import { loadFile, colorizeConfig } from './utils';
 import ModuleBundler from './ModuleBundler';
@@ -57,7 +58,7 @@ export default class ServerlessBuildPlugin {
 
     this.serverless = serverless;
 
-    if (!this.serverless.getVersion().startsWith('1')) {
+    if (!semver.lt(this.serverless.getVersion(), '1.0.0') {
       throw new this.serverless.classes.Error(
         'serverless-build-plugin requires serverless@1.x.x',
       );
@@ -144,8 +145,6 @@ export default class ServerlessBuildPlugin {
 
 
     this.hooks = {
-      'after:deploy:function:initialize'       : this.build,
-      'after:deploy:initialize'                : this.build,
       'after:deploy:createDeploymentArtifacts' : () => {
         this.serverless.service.package.artifact = null;
       },
@@ -158,6 +157,19 @@ export default class ServerlessBuildPlugin {
         return this.build();
       },
     };
+
+    // hooks change from 1.12
+    if (semver.gte(this.serverless.getVersion(), '1.12.0') {
+      this.hooks = Object.assign({
+        'before:package:initialize'          : this.build,
+        'before:package:function:initialize' : this.build,
+      }, this.hooks);
+    } else {
+      this.hooks = Object.assign({
+        'after:deploy:function:initialize'   : this.build,
+        'after:deploy:initialize'            : this.build,
+      }, this.hooks);
+    }
   }
 
   log = (...args) => this.serverless.cli.log(...args)

--- a/src/lib/ServerlessBuildPlugin.js
+++ b/src/lib/ServerlessBuildPlugin.js
@@ -85,23 +85,17 @@ export default class ServerlessBuildPlugin {
         const functionObject = this.serverless.service.getFunction(functionName);
         const funcPackageConfig = functionObject.package || {};
 
-        if (funcPackageConfig.artifact) {
-          if (process.env.SLS_DEBUG) {
-            this.serverless.cli.log('package.artifact is defined, skipping packaging');
-          }
+        const artifactFilePath = funcPackageConfig.artifact;
+        const packageFilePath = path.join(this.serverless.config.servicePath,
+          '.serverless',
+          zipFileName,
+        );
 
-          const artifactFilePath = funcPackageConfig.artifact;
-          const packageFilePath = path.join(this.serverless.config.servicePath,
-            '.serverless',
-            zipFileName
-          );
-
-          return copyFile(artifactFilePath, packageFilePath).then(() => {
-            functionObject.artifact = artifactFilePath;
-            return artifactFilePath;
-          })
-        };
-      }
+        return copyFile(artifactFilePath, packageFilePath).then(() => {
+          functionObject.artifact = artifactFilePath;
+          return artifactFilePath;
+        });
+      };
     }
 
     //
@@ -193,17 +187,17 @@ export default class ServerlessBuildPlugin {
     // hooks changed in 1.12 :/
     if (semver.gte(this.serverless.getVersion(), '1.12.0')) {
       this.hooks = Object.assign({
-        'before:package:initialize'                : this.build,
-        'before:package:function:initialize'       : this.build,
+        'before:package:initialize'               : this.build,
+        'before:package:function:initialize'      : this.build,
         'after:package:createDeploymentArtifacts' : () => {
           this.serverless.service.package.artifact = null;
         },
       }, this.hooks);
     } else {
       this.hooks = Object.assign({
-        'after:deploy:function:initialize'         : this.build,
-        'after:deploy:initialize'                  : this.build,
-        'after:deploy:createDeploymentArtifacts'   : () => {
+        'after:deploy:function:initialize'       : this.build,
+        'after:deploy:initialize'                : this.build,
+        'after:deploy:createDeploymentArtifacts' : () => {
           this.serverless.service.package.artifact = null;
         },
       }, this.hooks);

--- a/src/lib/ServerlessBuildPlugin.js
+++ b/src/lib/ServerlessBuildPlugin.js
@@ -6,7 +6,7 @@ import { typeOf, merge, clone } from 'lutils';
 import c from 'chalk';
 import semver from 'semver';
 
-import { loadFile, colorizeConfig } from './utils';
+import { loadFile, colorizeConfig, copyFile } from './utils';
 import ModuleBundler from './ModuleBundler';
 import SourceBundler from './SourceBundler';
 import FileBuild from './FileBuild';
@@ -58,16 +58,51 @@ export default class ServerlessBuildPlugin {
 
     this.serverless = serverless;
 
-    if (!semver.lt(this.serverless.getVersion(), '1.0.0') {
+    if (semver.lt(this.serverless.getVersion(), '1.0.0')) {
       throw new this.serverless.classes.Error(
         'serverless-build-plugin requires serverless@1.x.x',
       );
     }
 
-    // This causes the `package` plugin to be skipped
-    this.serverless.service.package.artifact     = true;
+    // put the package plugin into 'individual' mode
     this.serverless.service.package.individually = true;
 
+    // in sls 1.11 and lower this will skip 'archiving' (no effect in 1.12+)
+    this.serverless.service.package.artifact = true;
+
+    // in sls 1.12 and high this will skip 'archiving'
+    if (semver.gte(this.serverless.getVersion(), '1.12.0')) {
+      const packagePlugin = this.serverless.pluginManager.plugins.reduce((acc, val) => {
+        if (val.constructor.name === 'Package') {
+          return val;
+        }
+        return acc;
+      }, false);
+
+      packagePlugin.packageFunction = (functionName) => {
+        const zipFileName = `${functionName}.zip`;
+
+        const functionObject = this.serverless.service.getFunction(functionName);
+        const funcPackageConfig = functionObject.package || {};
+
+        if (funcPackageConfig.artifact) {
+          if (process.env.SLS_DEBUG) {
+            this.serverless.cli.log('package.artifact is defined, skipping packaging');
+          }
+
+          const artifactFilePath = funcPackageConfig.artifact;
+          const packageFilePath = path.join(this.serverless.config.servicePath,
+            '.serverless',
+            zipFileName
+          );
+
+          return copyFile(artifactFilePath, packageFilePath).then(() => {
+            functionObject.artifact = artifactFilePath;
+            return artifactFilePath;
+          })
+        };
+      }
+    }
 
     //
     // PLUGIN CONFIG GENERATION
@@ -145,9 +180,6 @@ export default class ServerlessBuildPlugin {
 
 
     this.hooks = {
-      'after:deploy:createDeploymentArtifacts' : () => {
-        this.serverless.service.package.artifact = null;
-      },
       'before:offline:start': () => {
         if (!this.config.useServerlessOffline) return null;
 
@@ -158,16 +190,22 @@ export default class ServerlessBuildPlugin {
       },
     };
 
-    // hooks change from 1.12
-    if (semver.gte(this.serverless.getVersion(), '1.12.0') {
+    // hooks changed in 1.12 :/
+    if (semver.gte(this.serverless.getVersion(), '1.12.0')) {
       this.hooks = Object.assign({
-        'before:package:initialize'          : this.build,
-        'before:package:function:initialize' : this.build,
+        'before:package:initialize'                : this.build,
+        'before:package:function:initialize'       : this.build,
+        'after:package:createDeploymentArtifacts' : () => {
+          this.serverless.service.package.artifact = null;
+        },
       }, this.hooks);
     } else {
       this.hooks = Object.assign({
-        'after:deploy:function:initialize'   : this.build,
-        'after:deploy:initialize'            : this.build,
+        'after:deploy:function:initialize'         : this.build,
+        'after:deploy:initialize'                  : this.build,
+        'after:deploy:createDeploymentArtifacts'   : () => {
+          this.serverless.service.package.artifact = null;
+        },
       }, this.hooks);
     }
   }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -17,6 +17,12 @@ export function walker(...args) {
   return w;
 }
 
+/**
+ * Wraps fs-extra copy
+ */
+export function copyFile(source, dest) {
+  return fs.copy(source, dest);
+}
 
 /**
  * Read any of:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,13 +1554,13 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fs-extra@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:
     graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -1671,7 +1671,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@~4.1.11:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@~4.1.11:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2298,9 +2298,9 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+jsonfile@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.0.tgz#92e7c7444e5ffd5fa32e6a9ae8b85034df8347d0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -2325,12 +2325,6 @@ kind-of@^3.0.2:
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -3091,11 +3085,7 @@ sax@^1.1.4:
   version "1.2.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -3381,6 +3371,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
 user-home@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,15 +196,7 @@ babel-cli@^6.24.1:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
-  version "6.20.0"
-  resolved "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
-  dependencies:
-    chalk "^1.1.0"
-    esutils "^2.0.2"
-    js-tokens "^2.0.0"
-
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -212,31 +204,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.18.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.21.0.tgz#75525480c21c803f826ef3867d22c19f080a3724"
-  dependencies:
-    babel-code-frame "^6.20.0"
-    babel-generator "^6.21.0"
-    babel-helpers "^6.16.0"
-    babel-messages "^6.8.0"
-    babel-register "^6.18.0"
-    babel-runtime "^6.20.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.21.0"
-    babel-types "^6.21.0"
-    babylon "^6.11.0"
-    convert-source-map "^1.1.0"
-    debug "^2.1.1"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    minimatch "^3.0.2"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-core@^6.24.1:
+babel-core@^6.0.0, babel-core@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -270,19 +238,7 @@ babel-eslint@^7.1.1:
     babylon "^6.13.0"
     lodash.pickby "^4.6.0"
 
-babel-generator@^6.18.0, babel-generator@^6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.21.0.tgz#605f1269c489a1c75deeca7ea16d43d4656c8494"
-  dependencies:
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.21.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-
-babel-generator@^6.24.1:
+babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
   dependencies:
@@ -345,7 +301,7 @@ babel-helper-flip-expressions@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz#7bab2cf61162bc92703e9b298ef512bcf77d6787"
 
-babel-helper-function-name@^6.24.1:
+babel-helper-function-name@^6.24.1, babel-helper-function-name@^6.8.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
   dependencies:
@@ -354,16 +310,6 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
-
-babel-helper-function-name@^6.8.0:
-  version "6.18.0"
-  resolved "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz#68ec71aeba1f3e28b2a6f0730190b754a9bf30e6"
-  dependencies:
-    babel-helper-get-function-arity "^6.18.0"
-    babel-runtime "^6.0.0"
-    babel-template "^6.8.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
 
 babel-helper-get-function-arity@^6.18.0:
   version "6.18.0"
@@ -424,13 +370,6 @@ babel-helper-to-multiple-sequence-expressions@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.4.tgz#d94414b386b6286fbaad77f073dea9b34324b01c"
 
-babel-helpers@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz#1095ec10d99279460553e67eb3eee9973d3867e3"
-  dependencies:
-    babel-runtime "^6.0.0"
-    babel-template "^6.16.0"
-
 babel-helpers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
@@ -459,12 +398,6 @@ babel-messages@^6.23.0:
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
-
-babel-messages@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz#bf504736ca967e6d65ef0adb5a2a5f947c8e0eb9"
-  dependencies:
-    babel-runtime "^6.0.0"
 
 babel-plugin-add-module-exports@^0.2.0:
   version "0.2.1"
@@ -880,18 +813,6 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz#892e2e03865078dd90ad2c715111ec4449b32a68"
-  dependencies:
-    babel-core "^6.18.0"
-    babel-runtime "^6.11.6"
-    core-js "^2.4.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.2.0"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.2"
-
 babel-register@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
@@ -904,31 +825,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.20.0, babel-runtime@^6.9.0:
-  version "6.20.0"
-  resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.8.0:
-  version "6.16.0"
-  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
-  dependencies:
-    babel-runtime "^6.9.0"
-    babel-traverse "^6.16.0"
-    babel-types "^6.16.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -938,21 +842,7 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-traverse@^6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.21.0.tgz#69c6365804f1a4f69eb1213f85b00a818b8c21ad"
-  dependencies:
-    babel-code-frame "^6.20.0"
-    babel-messages "^6.8.0"
-    babel-runtime "^6.20.0"
-    babel-types "^6.21.0"
-    babylon "^6.11.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.24.1:
+babel-traverse@^6.15.0, babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -966,16 +856,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.21.0, babel-types@^6.8.0, babel-types@^6.9.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
-  dependencies:
-    babel-runtime "^6.20.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.24.1:
+babel-types@^6.15.0, babel-types@^6.18.0, babel-types@^6.21.0, babel-types@^6.24.1, babel-types@^6.8.0, babel-types@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -1021,13 +902,6 @@ boom@2.x.x:
   resolved "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-brace-expansion@^1.0.0:
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
-  dependencies:
-    balanced-match "^0.4.1"
-    concat-map "0.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.7"
@@ -1503,7 +1377,7 @@ espree@^3.3.1:
     acorn "^4.0.1"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0, esprima@^2.7.1:
+esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -2110,11 +1984,11 @@ istanbul-api@^1.1.0-alpha.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0:
+istanbul-lib-coverage@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz#c3f9b6d226da12424064cce87fce0fb57fdfa7a2"
 
-istanbul-lib-coverage@^1.1.0:
+istanbul-lib-coverage@^1.0.0-alpha, istanbul-lib-coverage@^1.0.0-alpha.0, istanbul-lib-coverage@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#caca19decaef3525b5d6331d701f3f3b7ad48528"
 
@@ -2124,19 +1998,7 @@ istanbul-lib-hook@^1.0.0-alpha.4:
   dependencies:
     append-transform "^0.3.0"
 
-istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4, istanbul-lib-instrument@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.3.0.tgz#19f0a973397454989b98330333063a5b56df0e58"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.13.0"
-    istanbul-lib-coverage "^1.0.0"
-    semver "^5.3.0"
-
-istanbul-lib-instrument@^1.7.1:
+istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4, istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz#169e31bc62c778851a99439dd99c3cc12184d360"
   dependencies:
@@ -2370,14 +2232,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.5.1, js-yaml@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
-js-yaml@^3.8.4:
+js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@^3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
@@ -2686,17 +2541,11 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.25.0"
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -3242,9 +3091,13 @@ sax@^1.1.4:
   version "1.2.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3284,17 +3137,11 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-source-map-support@^0.4.15:
+source-map-support@^0.4.15, source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:
     source-map "^0.5.6"
-
-source-map-support@^0.4.2:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
-  dependencies:
-    source-map "^0.5.3"
 
 source-map@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
A change in serverless 1.12.0 disabled this plugins mechanism from preventing the archive step. This PR introduces a new mechanism for again preventing that step. It will only target serverless 1.12.0+ leaving the other intact for previous versions.

This PR also fixes the deprecated hooks and includes a Travic build file for good measure, see - https://travis-ci.org/kivlor/serverless-build-plugin