### PR TITLE
Strip async from non-async code. Seems to improve performance on Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
-node_js: ["6.10"]
+node_js: ["6.10", "8"]
 
 cache:
   yarn: true
-
-before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 script:
   - yarn
@@ -13,6 +10,9 @@ script:
   - yarn build
   - yarn test:prepare
   - DEBUG=true yarn coverage
+
+before_deploy:
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   provider: script

--- a/src/FileBuild.ts
+++ b/src/FileBuild.ts
@@ -49,7 +49,7 @@ export class FileBuild {
     fnConfig: { handler: string; },
     archive: Archiver,
   ) {
-    let builderFilePath = await this.tryBuildFiles();
+    let builderFilePath = this.tryBuildFiles();
 
     if (!builderFilePath) {
       throw new Error('Unrecognized build file path');
@@ -98,12 +98,10 @@ export class FileBuild {
 
       externals && externals.forEach((ext) => this.externals.add(ext));
 
-      await Bluebird.each([
-        buildFilename, `${buildFilename}.map`,
-      ], async (relPath) => {
+      [buildFilename, `${buildFilename}.map`].forEach((relPath) => {
         const filePath = path.resolve(this.buildTmpDir, relPath);
 
-        if (!await existsSync(filePath)) { return; }
+        if (!existsSync(filePath)) { return; }
 
         archive.file(filePath, { name: relPath });
       });
@@ -133,9 +131,9 @@ export class FileBuild {
   /**
    *  Allows for build files to be auto selected
    */
-  private async tryBuildFiles () {
+  private tryBuildFiles () {
     for (const fileName of this.tryFiles) {
-      if (await existsSync(fileName)) { return fileName; }
+      if (existsSync(fileName)) { return fileName; }
     }
 
     return null;

--- a/src/lib/Walker.ts
+++ b/src/lib/Walker.ts
@@ -13,7 +13,7 @@ export class Walker {
   }
 
   filter (fn) {
-    this.walker.filterDir(this.capture(fn));
+    this.walker.filterDir(fn);
 
     return this;
   }
@@ -36,7 +36,7 @@ export class Walker {
       this.walker.on('end', resolve);
     });
 
-    await Promise.all(this.pending);
+    return Promise.all(this.pending);
   }
 
   private capture = (fn) => {

--- a/src/lib/Walker.ts
+++ b/src/lib/Walker.ts
@@ -13,7 +13,7 @@ export class Walker {
   }
 
   filter (fn) {
-    this.walker.filterDir(fn);
+    this.walker.filterDir(this.capture(fn));
 
     return this;
   }


### PR DESCRIPTION
If there's a reason why this code was async, then please ignore and close this PR.

Otherwise, this PR:

- removes async when it's not needed, mainly around calls to `existsSync`
- not awaiting a promise, just to return a promise again
- move `childPackageJson` to after the cache check

These changes seemed to net a 10%-15% performance gain locally (MacOS, Node v8.2.1) when running the following script, placed in the project root:

```ts
import * as Archiver from 'archiver';
import * as path from 'path';
import { Logger } from './src/lib/Logger';
import { ModuleBundler } from './src/ModuleBundler';

const servicePath = path.resolve(__dirname, 'test/1.0');

const artifact = Archiver('zip', { store: true });
const moduleBundler = new ModuleBundler({
  servicePath,
  logger: new Logger(),
  archive: artifact,
});
console.time('all');
moduleBundler.bundle({}).then(() => console.timeEnd('all'))
```

Invoked with `$ node -r ts-node/register profile.ts`.

I have not tested with other projects or configurations (how do you do this easily?)